### PR TITLE
fix: serialize stdClass dynamic properties in Json::add()

### DIFF
--- a/WebFiori/Json/JsonConverter.php
+++ b/WebFiori/Json/JsonConverter.php
@@ -61,6 +61,8 @@ class JsonConverter {
             return $obj->toJSON();
         } else if ($obj instanceof Json) {
             return $obj;
+        } else if ($obj instanceof \stdClass) {
+            return new Json(get_object_vars($obj));
         }
 
         $methods = get_class_methods($obj);

--- a/tests/WebFiori/Tests/Json/JsonTest.php
+++ b/tests/WebFiori/Tests/Json/JsonTest.php
@@ -1632,4 +1632,27 @@ class JsonTest extends TestCase {
         $json = new Json();
         $this->assertEquals('snake',$json->getPropStyle());
     }
+    /**
+     * @test
+     * @see https://github.com/WebFiori/json/issues/54
+     */
+    public function testStdClassSerialization() {
+        $json = new Json();
+        $obj = (object)['status' => 'ok', 'message' => 'Hello'];
+        $json->add('data', $obj);
+        $decoded = json_decode($json->toJSONString(), true);
+        $this->assertEquals('ok', $decoded['data']['status']);
+        $this->assertEquals('Hello', $decoded['data']['message']);
+    }
+    /**
+     * @test
+     * @see https://github.com/WebFiori/json/issues/54
+     */
+    public function testStdClassInArray() {
+        $json = new Json();
+        $json->add('items', [(object)['id' => 1, 'name' => 'foo']]);
+        $decoded = json_decode($json->toJSONString(), true);
+        $this->assertEquals(1, $decoded['items'][0]['id']);
+        $this->assertEquals('foo', $decoded['items'][0]['name']);
+    }
 }


### PR DESCRIPTION
# Summary
Fix `Json::add()` to correctly serialize `stdClass` objects by reading their dynamic properties via `get_object_vars()`.

## Motivation
Users returning `stdClass` objects (e.g. via `(object)[...]` cast) get empty `{}` in JSON output. Fixes #54.

## Changes
- Added failing test cases that reproduce the bug

## How to Test / Verify
Unit tests: `testStdClassSerialization` and `testStdClassInArray` in `JsonTest.php`. Currently failing, confirming the bug.

## Breaking Changes and Migration Steps
None

## Checklist
- [x] I reviewed my own diff before requesting review
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I added/updated tests (or explained why not)
- [ ] I updated docs (if needed) [Docs Repo](https://github.com/WebFiori/docs)
- [ ] I ran lint/cs-fixer (if applicable) (`composer fix-cs`)
- [x] I considered backward compatibility
- [x] I considered security

## Related issues
Closes #54