### PR TITLE
release: merge dev into main

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,26 +169,42 @@ Output:
 
 For objects that don't implement `JsonI`, the library maps them automatically using two sources:
 
-1. **Public getter methods** — any method prefixed with `get` is called and its return value is added. The property name is the method name with `get` stripped (e.g. `getName()` → `Name`). Methods returning `null` or `false` are skipped.
+1. **Public getter methods** — any method prefixed with `get` is called and its return value is added, including `null` and `false`. The property name is the method name with `get` stripped (e.g. `getName()` → `Name`).
 2. **Public properties** — extracted via reflection and added as-is, including those with a `null` value.
 
+Use the `#[JsonIgnore]` attribute to exclude specific getters or properties from serialization.
+
 ```php
+use WebFiori\Json\Json;
+use WebFiori\Json\JsonIgnore;
+
 class Product {
-    public string $sku = 'ABC-001';       // added via reflection
+    public string $sku = 'ABC-001';
+
+    #[JsonIgnore]
+    public string $internalCode = 'X-99';  // excluded
+
     private string $name;
     private float $price;
+    private bool $available;
 
-    public function __construct(string $name, float $price) {
-        $this->name  = $name;
-        $this->price = $price;
+    public function __construct(string $name, float $price, bool $available) {
+        $this->name      = $name;
+        $this->price     = $price;
+        $this->available = $available;
     }
 
-    public function getName(): string { return $this->name; }   // → "Name"
-    public function getPrice(): float { return $this->price; }  // → "Price"
+    public function getName(): string { return $this->name; }          // → "Name"
+    public function getPrice(): float { return $this->price; }         // → "Price"
+    public function getAvailable(): bool { return $this->available; }  // → "Available" (false is included)
+    public function getDiscount(): ?float { return null; }             // → "Discount": null
+
+    #[JsonIgnore]
+    public function getSecretMargin(): float { return 0.42; }          // excluded
 }
 
 $json = new Json();
-$product = new Product('Keyboard', 49.99);
+$product = new Product('Keyboard', 49.99, false);
 $json->addObject('product', $product);
 
 echo $json;
@@ -197,7 +213,7 @@ echo $json;
 Output:
 
 ```json
-{"product":{"Name":"Keyboard","Price":49.99,"sku":"ABC-001"}}
+{"product":{"Name":"Keyboard","Price":49.99,"Available":false,"Discount":null,"sku":"ABC-001"}}
 ```
 
 ## Property Naming Styles

--- a/WebFiori/Json/JsonConverter.php
+++ b/WebFiori/Json/JsonConverter.php
@@ -73,11 +73,13 @@ class JsonConverter {
             $funcNm = substr($methods[$y], 0, 3);
 
             if (strtolower($funcNm) == 'get') {
-                $propVal = call_user_func([$obj, $methods[$y]]);
+                $refMethod = new \ReflectionMethod($obj, $methods[$y]);
 
-                if ($propVal !== false && $propVal !== null) {
-                    $json->add(substr($methods[$y], 3), $propVal);
+                if (!empty($refMethod->getAttributes(JsonIgnore::class))) {
+                    continue;
                 }
+                $propVal = call_user_func([$obj, $methods[$y]]);
+                $json->add(substr($methods[$y], 3), $propVal);
             }
         }
 
@@ -87,6 +89,9 @@ class JsonConverter {
         $publicProps = $reflection->getProperties(\ReflectionProperty::IS_PUBLIC);
 
         foreach ($publicProps as $prop) {
+            if (!empty($prop->getAttributes(JsonIgnore::class))) {
+                continue;
+            }
             $name = $prop->getName();
             $value = $prop->getValue($obj);
             $json->add($name, $value);

--- a/WebFiori/Json/JsonConverter.php
+++ b/WebFiori/Json/JsonConverter.php
@@ -61,6 +61,8 @@ class JsonConverter {
             return $obj->toJSON();
         } else if ($obj instanceof Json) {
             return $obj;
+        } else if ($obj instanceof \stdClass) {
+            return new Json(get_object_vars($obj));
         }
 
         $methods = get_class_methods($obj);

--- a/WebFiori/Json/JsonIgnore.php
+++ b/WebFiori/Json/JsonIgnore.php
@@ -1,0 +1,6 @@
+<?php
+namespace WebFiori\Json;
+
+#[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_PROPERTY)]
+class JsonIgnore {
+}

--- a/examples/04-object-auto-mapping.php
+++ b/examples/04-object-auto-mapping.php
@@ -3,29 +3,37 @@
 require_once __DIR__.'/../vendor/autoload.php';
 
 use WebFiori\Json\Json;
+use WebFiori\Json\JsonIgnore;
 
 class Product {
     public string $sku = 'ABC-001';
+
+    #[JsonIgnore]
+    public string $internalCode = 'X-99';  // excluded
+
     private string $name;
     private float $price;
+    private bool $available;
 
-    public function __construct(string $name, float $price) {
-        $this->name = $name;
-        $this->price = $price;
+    public function __construct(string $name, float $price, bool $available) {
+        $this->name      = $name;
+        $this->price     = $price;
+        $this->available = $available;
     }
 
-    public function getName(): string {
-        return $this->name;
-    }
-    public function getPrice(): float {
-        return $this->price;
-    }
+    public function getName(): string { return $this->name; }
+    public function getPrice(): float { return $this->price; }
+    public function getAvailable(): bool { return $this->available; }  // false is included
+    public function getDiscount(): ?float { return null; }             // null is included
+
+    #[JsonIgnore]
+    public function getSecretMargin(): float { return 0.42; }          // excluded
 }
 
 $json = new Json();
-$product = new Product('Keyboard', 49.99);
+$product = new Product('Keyboard', 49.99, false);
 $json->addObject('product', $product);
 
 echo $json."\n";
-// {"product":{"Name":"Keyboard","Price":49.99,"sku":"ABC-001"}}
-// ^ getters produce "Name"/"Price", public property adds "sku"
+// {"product":{"Name":"Keyboard","Price":49.99,"Available":false,"Discount":null,"sku":"ABC-001"}}
+// ^ false and null are serialized; #[JsonIgnore] properties/getters are excluded

--- a/tests/WebFiori/Tests/Json/JsonConverterTest.php
+++ b/tests/WebFiori/Tests/Json/JsonConverterTest.php
@@ -117,4 +117,46 @@ class JsonConverterTest extends TestCase {
         $this->assertTrue($json->hasKey('name'));
         $this->assertNull($json->get('name'));
     }
+    /**
+     * @test
+     * @see https://github.com/WebFiori/json/issues/57
+     */
+    public function testGetterReturningNullIsIncluded() {
+        $obj = new \WebFiori\Tests\ObjWithNullFalseGetters('Ibrahim', null, true);
+        $json = JsonConverter::objectToJson($obj);
+        $this->assertTrue($json->hasKey('MiddleName'));
+        $this->assertNull($json->get('MiddleName'));
+    }
+    /**
+     * @test
+     * @see https://github.com/WebFiori/json/issues/57
+     */
+    public function testGetterReturningFalseIsIncluded() {
+        $obj = new \WebFiori\Tests\ObjWithNullFalseGetters('Ibrahim', 'Ali', false);
+        $json = JsonConverter::objectToJson($obj);
+        $this->assertTrue($json->hasKey('Active'));
+        $this->assertFalse($json->get('Active'));
+    }
+    /**
+     * @test
+     * @see https://github.com/WebFiori/json/issues/57
+     */
+    public function testJsonIgnoreOnGetter() {
+        $obj = new \WebFiori\Tests\ObjWithNullFalseGetters('Ibrahim', null, true);
+        $json = JsonConverter::objectToJson($obj);
+        $this->assertFalse($json->hasKey('Secret'));
+    }
+    /**
+     * @test
+     * @see https://github.com/WebFiori/json/issues/57
+     */
+    public function testJsonIgnoreOnPublicProperty() {
+        $obj = new \WebFiori\Tests\ObjWithIgnoredProps();
+        $json = JsonConverter::objectToJson($obj);
+        $this->assertFalse($json->hasKey('internalId'));
+        $this->assertTrue($json->hasKey('name'));
+        $this->assertEquals('Ibrahim', $json->get('name'));
+        $this->assertTrue($json->hasKey('email'));
+        $this->assertNull($json->get('email'));
+    }
 }

--- a/tests/WebFiori/Tests/Json/JsonTest.php
+++ b/tests/WebFiori/Tests/Json/JsonTest.php
@@ -1632,4 +1632,27 @@ class JsonTest extends TestCase {
         $json = new Json();
         $this->assertEquals('snake',$json->getPropStyle());
     }
+    /**
+     * @test
+     * @see https://github.com/WebFiori/json/issues/54
+     */
+    public function testStdClassSerialization() {
+        $json = new Json();
+        $obj = (object)['status' => 'ok', 'message' => 'Hello'];
+        $json->add('data', $obj);
+        $decoded = json_decode($json->toJSONString(), true);
+        $this->assertEquals('ok', $decoded['data']['status']);
+        $this->assertEquals('Hello', $decoded['data']['message']);
+    }
+    /**
+     * @test
+     * @see https://github.com/WebFiori/json/issues/54
+     */
+    public function testStdClassInArray() {
+        $json = new Json();
+        $json->add('items', [(object)['id' => 1, 'name' => 'foo']]);
+        $decoded = json_decode($json->toJSONString(), true);
+        $this->assertEquals(1, $decoded['items'][0]['id']);
+        $this->assertEquals('foo', $decoded['items'][0]['name']);
+    }
 }

--- a/tests/WebFiori/Tests/ObjWithIgnoredProps.php
+++ b/tests/WebFiori/Tests/ObjWithIgnoredProps.php
@@ -1,0 +1,13 @@
+<?php
+namespace WebFiori\Tests;
+
+use WebFiori\Json\JsonIgnore;
+
+class ObjWithIgnoredProps {
+    #[JsonIgnore]
+    public string $internalId = 'abc-123';
+
+    public string $name = 'Ibrahim';
+
+    public ?string $email = null;
+}

--- a/tests/WebFiori/Tests/ObjWithNullFalseGetters.php
+++ b/tests/WebFiori/Tests/ObjWithNullFalseGetters.php
@@ -1,0 +1,33 @@
+<?php
+namespace WebFiori\Tests;
+
+use WebFiori\Json\JsonIgnore;
+
+class ObjWithNullFalseGetters {
+    private ?string $middleName;
+    private bool $active;
+    private string $name;
+
+    public function __construct(string $name, ?string $middleName, bool $active) {
+        $this->name = $name;
+        $this->middleName = $middleName;
+        $this->active = $active;
+    }
+
+    public function getName(): string {
+        return $this->name;
+    }
+
+    public function getMiddleName(): ?string {
+        return $this->middleName;
+    }
+
+    public function getActive(): bool {
+        return $this->active;
+    }
+
+    #[JsonIgnore]
+    public function getSecret(): string {
+        return 'hidden-value';
+    }
+}


### PR DESCRIPTION
# Summary
Merge all accumulated changes from `dev` into `main` for release.

## Changes
- fix: serialize stdClass dynamic properties in `Json::add()` (#54)
- feat!: include null/false getter values and add `#[JsonIgnore]` attribute (#57)
- Updated README and examples

## Breaking Changes and Migration Steps
- Objects that previously relied on returning `null` or `false` from getters to hide properties will now have those properties serialized. Use `#[JsonIgnore]` for explicit exclusion.

## Checklist
- [x] I reviewed my own diff before requesting review
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I added/updated tests (or explained why not)
- [x] I updated docs (if needed) [Docs Repo](https://github.com/WebFiori/docs)
- [ ] I ran lint/cs-fixer (if applicable) (`composer fix-cs`)
- [x] I considered backward compatibility
- [x] I considered security

## Related issues
Closes #54
Closes #57